### PR TITLE
Drop /etc/skel/public_html

### DIFF
--- a/etc/skel/public_html/.directory
+++ b/etc/skel/public_html/.directory
@@ -1,3 +1,0 @@
-[Desktop Entry]
-Icon=folder_html
-Type=Directory


### PR DESCRIPTION
At at times where almost all Linux machines had apache2 installed and
public_html was the 'standard' way of sharing files, this might have made
sense.

Nowayds, though, this is no longer the case.

http://bugzilla.opensuse.org/show_bug.cgi?id=1064226